### PR TITLE
fix(extensions): change portable extensions dir

### DIFF
--- a/src/service/pluginService.ts
+++ b/src/service/pluginService.ts
@@ -9,8 +9,8 @@ import * as util from "../util";
 const apiPath =
   "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery";
 
-const extensionDir: string = ".vscode";
-const extensionDirPortable: string = "/data/extensions/";
+const extensionDir: string = ".vscode/";
+const extensionDirPortable: string = "/extensions/";
 
 export class ExtensionInformation {
   public static fromJSON(text: string) {


### PR DESCRIPTION
#### Short description of what this resolves:
Solves the issue #756 caused by a hardcoded extension dir.
This is a temporary workaround and we should use the env variables to check a valid extension dir instead of hardcoded ones:

#### Changes proposed in this pull request:

- The `extensionDir` variable was changed to `.vscode/` to prevent the sync of "something" with `.vscode` in its name. (ex: `bung87.vscode-gemfile`)
https://github.com/chase9/code-settings-sync/blob/36461174f534fefc4bce03a6f4ca182090287360/src/service/pluginService.ts#L12

- The `extensionDirPortable` variable was changed to `/extensions/` because the path for the extensions folder in a portable VSCode instance, is `extensions`
https://github.com/chase9/code-settings-sync/blob/36461174f534fefc4bce03a6f4ca182090287360/src/service/pluginService.ts#L13
Ref to `extensions` path in vscode:
https://github.com/Microsoft/vscode/blob/14f25a610224cea1b7fc97da63ad2304951f60a5/src/vs/platform/environment/node/environmentService.ts#L168



**Fixes**: #756

#### How Has This Been Tested?
The extension was "installed" in a portable vscode and executed to sync the settings. It works nicely.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution](https://github.com/shanalikhan/code-settings-sync/blob/master/CONTRIBUTING.md#setup-extension-locally) guidelines.
- [ ] My change requires a change to the documentation and Github Wiki.
- [ ] I have updated the documentation and Wiki accordingly.
